### PR TITLE
Add CLI solver and docs for 4equals10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,48 +3,50 @@ Solve 4=10 puzzles
 
 ## About
 
-- In January, 2023 I came across an Android game called `4=10` in
-  which one is presented with four digits and has to use a combination of
-  arithmetic operators (+, -, \*, /), parentheses (at most one pair), and
-  reordering of the digits to construct an equation equal to 10. For
-  example, a solution for the four digits '0254' is '0 + (4 - 2) * 5'.
-- After playing the game a bit, I considered trying to solve the game with
-  a python program and did some back-of-the-envelope calculations.
-  - python should be able to eval a string like `9 + ( 4 - 2 ) / 3` on my
-    MacBook Pro in less than (and perhaps much less than) `one ten-millionth`
-    of a second.
-  - The number of reorderings (permutations) of four digits is bounded by and
-    on the order of `10^4 = 10,000`.
-  - The number of ways to choose three arithmetic operators is `4^3 = 64`.
-  - There are at most `5` meaningful ways to add a single pair of parentheses
-    to an equation with four digits and three arithmetic operators.
-  - Putting the above points together, there are no more than about 3 million
-    equations that python would need to eval in order to determine a solution
-    for any particular four digits. My take was a python program to solve any
-    four digits would run in less that a second.
-  - I wrote the code you see here. My solution is simple and does not attempt
-    any optimizations, but even so it ran fast enough that it could solve
-    every sequence of four digits in about 20 seconds.
-  - I spent some additional time updating this program to
-    handle any number of digits, any operators, and arbitrary sums.  It can be
-    very slow when there are a lot of digits, especially for cases that have
-    no solution.
+This repository provides a small Python CLI that solves the `4 = 10` style
+arithmetic puzzle. Given a string of digits (for example `0254`), the solver
+searches through operator combinations, optional parentheses, and optional
+reordering of the digits to find an expression that equals a target value.
+The default target is 10, but it can be customized.
+
+## Getting started
+
+1. Create a virtual environment with Python 3.11+.
+2. Install the project locally (this also enables the `fourten` console script):
+
+   ```bash
+   python -m pip install -e .
+   ```
+
+Run `fourten --help` to see all available options.
 
 ## Usage examples
-- `fourten - Prints solutions for all four-digit sequences.
-- `fourten -e 20` - Prints solutions for all four-digit sequences when
-  the equation should equal 20.
-- `fourten -e 4 -nd 3` - Prints solutions for all three-digit
-  sequences when the equation should equal 4.
-- `fourten -d 123456 -e 25` - Finds a solution, if it exists, for the six
-  digits 123456 that equals 25, e.g., `1 * 2 + 3 * 4 + 5 + 6`.
-- `fourten -d 123456 -e 19 -o '+-'` - Find a solution for the six
-  digits 123456 that equals 19 using only addition and subtraction.
 
-## Some details
-- A "simple" solution without parentheses and reordering will be shown and labeled `on`
-  if it exists.
-- If no simple solution exists, the program will attempt, in order, to find:
-  - a solution with parentheses (`op`).
-  - a solution with reordering and no parentheses (`rn`).
-  - a solution with reordering and parentheses (`rp`).
+- `fourten` – Scan every four-digit sequence and print any solutions that
+  evaluate to 10.
+- `fourten -e 20` – Scan every four-digit sequence for expressions that equal
+  20 instead of 10.
+- `fourten -e 4 -nd 3` – Scan every three-digit sequence for expressions that
+  equal 4.
+- `fourten -d 123456 -e 25` – Solve a specific digit string, e.g. `1 * 2 + 3 *
+  4 + 5 + 6` equals 25.
+- `fourten -d 123456 -e 19 -o '+-'` – Solve a digit string while restricting the
+  operators to addition and subtraction.
+
+## How solutions are classified
+
+The solver reports the first expression it finds, categorizing it by the
+features it needed:
+
+- `on`: ordered digits, no parentheses
+- `op`: ordered digits, with parentheses
+- `rn`: reordered digits, no parentheses
+- `rp`: reordered digits, with parentheses
+
+## Running tests
+
+Tests use `pytest`. After installing the project in editable mode, run:
+
+```bash
+pytest
+```

--- a/fourten/__init__.py
+++ b/fourten/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for the 4equals10 solver."""
+
+from .solver import Solution, find_solution, scan_all
+
+__all__ = ["Solution", "find_solution", "scan_all"]

--- a/fourten/__main__.py
+++ b/fourten/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fourten/cli.py
+++ b/fourten/cli.py
@@ -1,0 +1,97 @@
+"""Command line interface for the 4equals10 solver."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from typing import Iterable
+
+from .solver import Solution, find_solution, scan_all
+
+
+CATEGORY_DESCRIPTIONS = {
+    "on": "ordered, no parentheses",
+    "op": "ordered, with parentheses",
+    "rn": "reordered, no parentheses",
+    "rp": "reordered, with parentheses",
+}
+
+
+def _solution_as_row(solution: Solution) -> str:
+    label = CATEGORY_DESCRIPTIONS.get(solution.category, solution.category)
+    return f"{solution.digits}: {solution.expression}  [{label}]"
+
+
+def _solutions_to_rows(solutions: Iterable[Solution]) -> str:
+    return "\n".join(_solution_as_row(solution) for solution in solutions)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Search for expressions that make the given digits equal the target.",
+    )
+    parser.add_argument(
+        "-d",
+        "--digits",
+        help="Digit string to solve (e.g. 0254). If omitted, all digit strings of length --num-digits are scanned.",
+    )
+    parser.add_argument(
+        "-nd",
+        "--num-digits",
+        type=int,
+        default=4,
+        help="Number of digits to scan when --digits is not provided.",
+    )
+    parser.add_argument(
+        "-e",
+        "--equals",
+        type=float,
+        default=10,
+        help="Target value the expression should equal.",
+    )
+    parser.add_argument(
+        "-o",
+        "--operators",
+        default="+-*/",
+        help="Operators to consider between digits.",
+    )
+    parser.add_argument(
+        "--show-json",
+        action="store_true",
+        help="Print results as JSON for easier scripting.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.digits:
+        solution = find_solution(args.digits, target=args.equals, operators=args.operators)
+        if not solution:
+            print(f"No solution found for digits={args.digits} with target {args.equals}.")
+            return 1
+        if args.show_json:
+            import json
+
+            print(json.dumps(asdict(solution), indent=2))
+        else:
+            print(_solution_as_row(solution))
+        return 0
+
+    solutions = list(
+        scan_all(num_digits=args.num_digits, target=args.equals, operators=args.operators)
+    )
+    if args.show_json:
+        import json
+
+        payload = [asdict(solution) for solution in solutions]
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_solutions_to_rows(solutions))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fourten/solver.py
+++ b/fourten/solver.py
@@ -1,0 +1,218 @@
+"""Solver logic for 4=10 style equations.
+
+The solver searches for expressions that reach a target value using a set of
+single-digit numbers, arithmetic operators, optional reordering of the digits,
+and optional parentheses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from itertools import permutations, product
+from typing import Iterable, List, Sequence, Tuple
+
+
+actionable_ops = {"+", "-", "*", "/"}
+
+
+@dataclass(frozen=True)
+class Solution:
+    """Represents a solution expression for a digit sequence."""
+
+    digits: str
+    expression: str
+    value: float
+    category: str
+
+
+class InvalidOperatorError(ValueError):
+    pass
+
+
+class InvalidDigitError(ValueError):
+    pass
+
+
+def _apply_operator(left: float, right: float, operator: str) -> float | None:
+    if operator == "+":
+        return left + right
+    if operator == "-":
+        return left - right
+    if operator == "*":
+        return left * right
+    if operator == "/":
+        if right == 0:
+            return None
+        return left / right
+    raise InvalidOperatorError(f"Unsupported operator: {operator}")
+
+
+@lru_cache(maxsize=None)
+def _parenthesized_expressions(
+    numbers: Tuple[int, ...], operators: Tuple[str, ...]
+) -> List[Tuple[str, float]]:
+    if len(numbers) == 1:
+        value = float(numbers[0])
+        return [(str(numbers[0]), value)]
+
+    expressions: List[Tuple[str, float]] = []
+    for index in range(1, len(numbers)):
+        left_numbers = numbers[:index]
+        right_numbers = numbers[index:]
+        left_ops = operators[: index - 1]
+        right_ops = operators[index:]
+        pivot_op = operators[index - 1]
+
+        for left_expr, left_val in _parenthesized_expressions(left_numbers, left_ops):
+            for right_expr, right_val in _parenthesized_expressions(
+                right_numbers, right_ops
+            ):
+                result = _apply_operator(left_val, right_val, pivot_op)
+                if result is None:
+                    continue
+                expression = f"({left_expr} {pivot_op} {right_expr})"
+                expressions.append((expression, result))
+
+    return expressions
+
+
+def _standard_precedence_value(numbers: Sequence[int], operators: Sequence[str]) -> float | None:
+    values: List[float | str] = [float(numbers[0])]
+    for op, number in zip(operators, numbers[1:]):
+        if op in {"*", "/"}:
+            left_value = float(values.pop())
+            right_value = float(number)
+            result = _apply_operator(left_value, right_value, op)
+            if result is None:
+                return None
+            values.append(result)
+        else:
+            values.append(op)
+            values.append(float(number))
+
+    total = float(values[0])
+    for idx in range(1, len(values), 2):
+        op = values[idx]
+        right = float(values[idx + 1])
+        result = _apply_operator(total, right, op)  # type: ignore[arg-type]
+        if result is None:
+            return None
+        total = result
+    return total
+
+
+def _is_close(value: float, target: float, tolerance: float = 1e-6) -> bool:
+    return abs(value - target) <= tolerance
+
+
+def _normalize_digits(digits: str) -> Tuple[int, ...]:
+    if not digits or not digits.isdigit():
+        raise InvalidDigitError("Digits must be a non-empty string of numbers.")
+    return tuple(int(d) for d in digits)
+
+
+def _normalize_operators(operators: str) -> Tuple[str, ...]:
+    normalized = tuple(operators)
+    unsupported = sorted(set(normalized) - actionable_ops)
+    if unsupported:
+        raise InvalidOperatorError(f"Unsupported operators provided: {' '.join(unsupported)}")
+    return normalized
+
+
+def unique_permutations(items: Sequence[int]) -> Iterable[Tuple[int, ...]]:
+    seen: set[Tuple[int, ...]] = set()
+    for perm in permutations(items):
+        if perm in seen:
+            continue
+        seen.add(perm)
+        yield perm
+
+
+def _expression_without_parentheses(
+    digits: Sequence[int], operators: Sequence[str]
+) -> Tuple[str, float | None]:
+    operator_sequence = tuple(operators)
+    expression_parts: List[str] = []
+    for digit, operator in zip(digits, operator_sequence + ("",)):
+        expression_parts.append(str(digit))
+        if operator:
+            expression_parts.append(f" {operator} ")
+    expression = "".join(expression_parts)
+    value = _standard_precedence_value(digits, operator_sequence)
+    return expression, value
+
+
+def _find_solution_for_order(
+    digits: Tuple[int, ...],
+    operator_pool: Tuple[str, ...],
+    target: float,
+    with_parentheses: bool,
+) -> Tuple[str, float] | None:
+    slots = len(digits) - 1
+    for operators in product(operator_pool, repeat=slots):
+        if with_parentheses:
+            for expression, value in _parenthesized_expressions(digits, operators):
+                if _is_close(value, target):
+                    return expression, value
+        else:
+            expression, value = _expression_without_parentheses(digits, operators)
+            if value is not None and _is_close(value, target):
+                return expression, value
+    return None
+
+
+def find_solution(
+    digits: str,
+    *,
+    target: float = 10,
+    operators: str = "+-*/",
+) -> Solution | None:
+    numeric_digits = _normalize_digits(digits)
+    operator_pool = _normalize_operators(operators)
+
+    modes = (
+        ("on", False),
+        ("op", True),
+        ("rn", False),
+        ("rp", True),
+    )
+
+    for mode, with_parentheses in modes:
+        orders: Iterable[Tuple[int, ...]]
+        if mode in {"rn", "rp"}:
+            orders = unique_permutations(numeric_digits)
+        else:
+            orders = (numeric_digits,)
+
+        for order in orders:
+            result = _find_solution_for_order(
+                order, operator_pool, target, with_parentheses=with_parentheses
+            )
+            if result:
+                expression, value = result
+                return Solution(
+                    digits="".join(str(d) for d in order),
+                    expression=expression,
+                    value=value,
+                    category=mode,
+                )
+
+    return None
+
+
+def scan_all(
+    *,
+    num_digits: int = 4,
+    target: float = 10,
+    operators: str = "+-*/",
+) -> Iterable[Solution]:
+    operator_pool = _normalize_operators(operators)
+    if num_digits < 1:
+        raise InvalidDigitError("Number of digits must be at least one.")
+
+    for number in range(10**num_digits):
+        digits = str(number).zfill(num_digits)
+        solution = find_solution(digits, target=target, operators="".join(operator_pool))
+        if solution:
+            yield solution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "fourten"
+version = "0.1.0"
+description = "Solve 4=10-style arithmetic puzzles from the command line"
+authors = [{name = "4equals10"}]
+requires-python = ">=3.11"
+readme = "README.md"
+
+[project.scripts]
+fourten = "fourten.cli:main"
+
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,33 @@
+import math
+
+import pytest
+
+from fourten.solver import InvalidDigitError, InvalidOperatorError, Solution, find_solution, scan_all
+
+
+def test_find_solution_for_known_digits():
+    solution = find_solution("0254")
+    assert solution is not None
+    assert math.isclose(solution.value, 10)
+    assert set(solution.expression) >= {"0", "2", "4", "5"}
+
+
+def test_invalid_digits_raise_error():
+    with pytest.raises(InvalidDigitError):
+        find_solution("12a3")
+
+
+def test_invalid_operator_raises_error():
+    with pytest.raises(InvalidOperatorError):
+        find_solution("1234", operators="+-x")
+
+
+def test_scan_all_respects_digit_count():
+    solutions = list(scan_all(num_digits=2, target=3, operators="+-"))
+    assert all(len(solution.digits) == 2 for solution in solutions)
+    assert solutions, "Expected at least one two-digit solution for target 3"
+
+
+def test_solution_dataclass_repr():
+    solution = Solution(digits="1234", expression="1 + 2 + 3 + 4", value=10, category="on")
+    assert "1234" in repr(solution)


### PR DESCRIPTION
## Summary
- add a Python solver module and CLI for 4equals10-style puzzles with packaging metadata
- cover solver behaviors with pytest-based tests
- refresh the README with installation, usage, and classification guidance

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444019bab0832086bc762f7c75ca8f)